### PR TITLE
Mandate using unsafe blocks inside unsafe fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Highly Dependable Location Tracker
 
 ## Requirements
-[Rust 1.51](https://www.rust-lang.org/learn/get-started)
+[Rust 1.52](https://www.rust-lang.org/learn/get-started)
 *(only tested Linux)*
 
 ## Directory/Crate overview

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 pub(crate) mod correct_driver;
 pub(crate) mod correct_witness;
 pub(crate) mod hdlt_api;

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use tokio::sync::RwLock;
 use tracing::*;
 

--- a/lib/model/src/lib.rs
+++ b/lib/model/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::new_without_default)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 macro_rules! partial_eq_impl {
     ($T:ty, $U:ty ; $($field:ident),+) => {

--- a/lib/model/src/position_proof.rs
+++ b/lib/model/src/position_proof.rs
@@ -77,13 +77,15 @@ impl UnverifiedPositionProof {
     /// Keep in mind that the number of tolerated faults associated with a PositionProof may not be trivial. See [PositionProof::max_faults].
     ///
     /// # Safety
-    /// All witnesses must share the same request, and [UnverifiedProximityProof::verify] must be safe to call on all of them.
+    /// All witnesses must share the same request, and [UnverifiedProximityProof::verify_unchecked] must be safe to call on all of them.
     /// There may not be any duplicate witnesses.
+    /// This function is always memory-safe, even if the above above conditions don't apply.
     pub unsafe fn verify_unchecked(self) -> PositionProof {
         let witnesses = self
             .witnesses
             .into_iter()
-            .map(|p| p.verify_unchecked())
+            // Safety: guaranteed by caller, always memory-safe
+            .map(|p| unsafe { p.verify_unchecked() })
             .collect();
 
         PositionProof { witnesses }

--- a/lib/model/src/proximity_proof.rs
+++ b/lib/model/src/proximity_proof.rs
@@ -126,10 +126,11 @@ impl UnverifiedProximityProof {
     /// Caller must guarantee that the request is valid, or in other words
     /// that it is safe to call [UnverifiedProximityProofRequest::verify_unchecked] on it; and
     /// that it is signed by a user entity that is not the author of the request (prover).
+    /// This function is always memory-safe, even if the above above conditions don't apply.
     pub unsafe fn verify_unchecked(self) -> ProximityProof {
         ProximityProof {
-            // Safety: guaranteed by caller
-            request: self.request.verify_unchecked(),
+            // Safety: guaranteed by caller, always memory-safe
+            request: unsafe { self.request.verify_unchecked() },
             witness_id: self.witness_id,
             witness_position: self.witness_position,
             signature: self.signature,

--- a/lib/model/src/proximity_proof_request.rs
+++ b/lib/model/src/proximity_proof_request.rs
@@ -95,6 +95,7 @@ impl UnverifiedProximityProofRequest {
     ///
     /// # Safety
     /// Caller must guarantee that the request is signed by a user entity.
+    /// This function is always memory-safe, even if the above above conditions don't apply.
     pub unsafe fn verify_unchecked(self) -> ProximityProofRequest {
         ProximityProofRequest {
             prover_id: self.prover_id,

--- a/lib/protos/src/lib.rs
+++ b/lib/protos/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 pub mod hdlt {
     tonic::include_proto!("hdlt");
 }

--- a/lib/tracing-utils/src/lib.rs
+++ b/lib/tracing-utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use thiserror::Error;
 
 mod metadata_mappers;

--- a/lib/tracing-utils/tracing-utils-macros/src/lib.rs
+++ b/lib/tracing-utils/tracing-utils-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use proc_macro::{Span, TokenStream};
 use proc_macro_error::*;
 use quote::ToTokens;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_op_in_unsafe_fn)]
+
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;


### PR DESCRIPTION
Our code uses unsafe to enforce more than memory safety.
To restrict unsafe code to where it is truly necessary, the
unsafe_block_in_unsafe_fn lint is perfect.

Bumps MSRV to 1.52